### PR TITLE
Fixed readme to remove reference to looker_java1.7 and rename looker_…

### DIFF
--- a/startup_scripts/README.md
+++ b/startup_scripts/README.md
@@ -2,8 +2,7 @@
 
 Publicly available scripts for on-premise hosted Looker customer startup.
 
-* looker_java1.7: Startup script for looker running under Java 1.7.  Should be in the /home/looker/looker directory with the looker.jar file. Please note that all current versions of Looker require Java 1.8 so this script is included for historic reasons.
-* looker_java1.8: Startup script for looker running under Java 1.8.  Should be in the /home/looker/looker directory with the looker.jar file, and it should be named looker. The full path to the file will commonly be /home/looker/looker/looker. Use this script for all current versions of Looker.
+* looker: Startup script for looker running under Java 1.8.  Should be in the /home/looker/looker directory with the looker.jar file, and it should be named looker. The full path to the file will commonly be /home/looker/looker/looker. Use this script for all current versions of Looker.
 * looker_init: Ubuntu init file to start Looker automatically on boot.  This may need some customization depending on user/directory for Looker.  This will also need to be modified to work with RedHat-based Linux distributions.
 * looker_mac: A version of the startup script customized for OSX. May require customization.
 * monitrc: Very basic sample monitrc to manage the Looker process. 


### PR DESCRIPTION
…java1.8

I eliminated the looker_java1.7 script and renamed looker_java1.8 in https://github.com/looker/customer-scripts/pull/8, but I did not modify the README.md. This fixes that.

@aabrahamian 