### PR TITLE
remove java version check, Looker does this

### DIFF
--- a/startup_scripts/looker_mac
+++ b/startup_scripts/looker_mac
@@ -1,11 +1,5 @@
 #!/bin/sh
 
-JAVA_VER=$(java -version 2>&1 | sed 's/java version "\(.*\)\.\(.*\)\..*"/\1\2/; 1q')
-if [ "$JAVA_VER" -le 17 ]; then
-  echo "The Java version installed on this host is too old. Please upgrade to the latest version of Java 8."
-  exit 1
-fi
-
 HOSTTYPE=`uname -s`
 
 cd $HOME/looker 


### PR DESCRIPTION
as per Chris Seymour it's handy to allow openjdk on the mac