### PR TITLE
Change java mem default in ansible example script

### DIFF
--- a/lookerapp_ansible/templates/looker.j2
+++ b/lookerapp_ansible/templates/looker.j2
@@ -3,10 +3,8 @@
 cd $HOME/looker 
 # set your java memory- there should be over 1.5G of system memory 
 # left to run the OS
-# set your java memory- there should be over 1.5G of system memory 
-# left to run the OS
 MEM=`cat /proc/meminfo | grep MemTotal | awk '{print $2}'`
-JM=`expr $MEM - 1500000`
+JM=`expr $MEM \* 6 / 10`
 JAVAMEM="${JM}k"
 
 


### PR DESCRIPTION
A couple of customers have hit OOM issues when allocating all but 1.5gb of the system mem to the Looker process so I changed this to the same config as the default script.