### PR TITLE
Use PrintGCDateStamps over PrintGCTimeStamps

### DIFF
--- a/startup_scripts/looker
+++ b/startup_scripts/looker
@@ -53,7 +53,7 @@ start() {
     java \
   -XX:+UseG1GC -XX:MaxGCPauseMillis=2000 -XX:MaxMetaspaceSize=$METAMEM \
   -Xms$JAVAMEM -Xmx$JAVAMEM \
-  -verbose:gc -XX:+PrintGCDetails -XX:+PrintGCTimeStamps \
+  -verbose:gc -XX:+PrintGCDetails -XX:+PrintGCDateStamps \
   -Xloggc:/tmp/gc.log  ${JAVAARGS} \
   -jar looker.jar start ${LOOKERARGS}
 


### PR DESCRIPTION
Small change to use -XX:+PrintGCDateStamps instead of -XX:+PrintGCTimeStamps for easier parsing of the GC logs. PrintGCTimeStamps will show the number of seconds since Looker started for garbage collection events, whereas PrintGCDateStamps will show the raw timestamps of the GC events.

https://www.oracle.com/technetwork/articles/java/vmoptions-jsp-140102.html