### PR TITLE
fixed to adhere to the results of checkbashisms script

### DIFF
--- a/startup_scripts/looker
+++ b/startup_scripts/looker
@@ -76,7 +76,7 @@ stop() {
         if [ $ECODE -gt 7 ] ; then
             kill $pid
         fi
-        for i in {1..30}; do
+        for i in $(seq 1 30); do
             timeout 20 curl -m 5 -ks ${PROTOCOL}://127.0.0.1:${LOOKERPORT}/alive > /dev/null 2>&1
             ECODE=$?
             if [ $ECODE -eq 7 ]; then

--- a/startup_scripts/looker11
+++ b/startup_scripts/looker11
@@ -88,7 +88,7 @@ stop() {
         if [ $ECODE -gt 7 ] ; then
             kill $pid
         fi
-        for i in {1..30}; do
+        for i in $(seq 1 30); do
             timeout 20 curl -m 5 -ks ${PROTOCOL}://127.0.0.1:${LOOKERPORT}/alive > /dev/null 2>&1
             ECODE=$?
             if [ $ECODE -eq 7 ]; then


### PR DESCRIPTION
found a "lint" type issue using the `checkbashisms` tool that identifies bash only features used in scripts calling for /bin/sh. The /bin/sh interpreter is often linked to /bin/bash but not always.