### PR TITLE
Allows SSL termination at the load balancer

### DIFF
--- a/startup_scripts/looker
+++ b/startup_scripts/looker
@@ -24,7 +24,7 @@ fi
 # check if --no-ssl is specified in LOOKERARGS and set protocol accordingly
 PROTOCOL=""
 
-echo "${LOOKERARGS}" | grep -q "\-\-no\-ssl"
+echo "${LOOKERARGS}" | grep -e "\-\-no\-ssl" -e "\-\-ssl-provided-externally-by"
 if [ $? -eq 0 ] 
 then
 	PROTOCOL='http'

--- a/startup_scripts/looker11
+++ b/startup_scripts/looker11
@@ -16,9 +16,9 @@ cd $HOME/looker
 # set your java memory- there should be over 1.5G of system memory 
 # left to run the OS
 MEM=`cat /proc/meminfo | grep MemTotal | awk '{print $2}'`
-JM=`expr $MEM \* 6 / 10`
+JM=`expr $MEM \* 8 / 10`
 JAVAMEM="${JM}k"
-METAMEM="800m"
+METAMEM="2800m"
 
 # Extra Java startup args and Looker startup args.  These can also be set in
 # a file named lookerstart.cfg

--- a/startup_scripts/looker11
+++ b/startup_scripts/looker11
@@ -40,7 +40,7 @@ fi
 # check if --no-ssl is specified in LOOKERARGS and set protocol accordingly
 PROTOCOL=""
 
-echo "${LOOKERARGS}" | grep -q "\-\-no\-ssl"
+echo "${LOOKERARGS}" | grep -e "\-\-no\-ssl" -e "\-\-ssl-provided-externally-by"
 if [ $? -eq 0 ] 
 then
 	PROTOCOL='http'

--- a/startup_scripts/looker_mac
+++ b/startup_scripts/looker_mac
@@ -39,7 +39,7 @@ fi
 PROTOCOL=""
 LOOKERPORT=${LOOKERPORT:-"9999"}
 
-echo "${LOOKERARGS}" | grep -q "\-\-no\-ssl"
+echo "${LOOKERARGS}" | grep -e "\-\-no\-ssl" -e "\-\-ssl-provided-externally-by"
 if [ $? -eq 0 ] 
 then
 	PROTOCOL='http'


### PR DESCRIPTION
Without checking for the `--ssl-provided-externally-by=` this leads to Looker crashing, as it is trying to communicate with `https`.  This prevents SSL termination at the load balancer from working correctly.