### PR TITLE
force-gcm-encryption is no longer needed

### DIFF
--- a/startup_scripts/looker
+++ b/startup_scripts/looker
@@ -14,7 +14,7 @@ JMXARGS="-Dcom.sun.akuma.jvmarg.com.sun.management.jmxremote -Dcom.sun.akuma.jvm
 
 # to set up JMX monitoring, add JMXARGS to JAVAARGS
 JAVAARGS=""
-LOOKERARGS="--force-gcm-encryption"
+LOOKERARGS=""
 
 # check for a lookerstart.cfg file to set JAVAARGS and LOOKERARGS
 if [ -r ./lookerstart.cfg ]; then


### PR DESCRIPTION
as of 22.6 looker starts with GCM by default

the presence of this flag won't cause any errors, it is simply ignored.  however it can raise questions or cause confusion.