### PR TITLE
Disable Nashorn optimistic types for JDK 11

### DIFF
--- a/startup_scripts/looker11
+++ b/startup_scripts/looker11
@@ -25,7 +25,7 @@ METAMEM="800m"
 JMXARGS="-Dcom.sun.akuma.jvmarg.com.sun.management.jmxremote -Dcom.sun.akuma.jvmarg.com.sun.management.jmxremote.port=9910 -Dcom.sun.akuma.jvmarg.com.sun.management.jmxremote.ssl=false -Dcom.sun.akuma.jvmarg.com.sun.management.jmxremote.local.only=false -Dcom.sun.akuma.jvmarg.com.sun.management.jmxremote.authenticate=true -Dcom.sun.akuma.jvmarg.com.sun.management.jmxremote.access.file=${HOME}/.lookerjmx/jmxremote.access -Dcom.sun.akuma.jvmarg.com.sun.management.jmxremote.password.file=${HOME}/.lookerjmx/jmxremote.password"
 
 # Starting with JDK9 some reflective accesses log warning messages, these java
-# args increase module visibilty and so supress the output
+# args increase module visibility and so suppress the output
 REFLECTIVE_ACCESS_ARGS="--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.math=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.util.concurrent=ALL-UNNAMED --add-opens java.base/java.net=ALL-UNNAMED --add-opens java.base/java.text=ALL-UNNAMED"
 
 # Disable optimistic typing in Nashorn (the JDK Javascript interpreter).

--- a/startup_scripts/looker11
+++ b/startup_scripts/looker11
@@ -12,8 +12,8 @@ if [ "$JAVA_VER" -ne 11 ]; then
   exit 1
 fi
 
-cd $HOME/looker 
-# set your java memory- there should be over 1.5G of system memory 
+cd $HOME/looker
+# set your java memory- there should be over 1.5G of system memory
 # left to run the OS
 MEM=`cat /proc/meminfo | grep MemTotal | awk '{print $2}'`
 JM=`expr $MEM \* 6 / 10`
@@ -28,6 +28,11 @@ JMXARGS="-Dcom.sun.akuma.jvmarg.com.sun.management.jmxremote -Dcom.sun.akuma.jvm
 # args increase module visibilty and so supress the output
 REFLECTIVE_ACCESS_ARGS="--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.math=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.util.concurrent=ALL-UNNAMED --add-opens java.base/java.net=ALL-UNNAMED --add-opens java.base/java.text=ALL-UNNAMED"
 
+# Disable optimistic typing in Nashorn (the JDK Javascript interpreter).
+# This flag defaults to True in JDK 11 (previously False in JDK 8) and in this
+# configuration it causes large spikes in Metaspace use in some circumstances.
+export NASHORN_ARGS="-Dnashorn.args=--optimistic-types=false"
+
 # to set up JMX monitoring, add JMXARGS to JAVAARGS
 JAVAARGS=""
 LOOKERARGS="--force-gcm-encryption"
@@ -41,7 +46,7 @@ fi
 PROTOCOL=""
 
 echo "${LOOKERARGS}" | grep -q "\-\-no\-ssl"
-if [ $? -eq 0 ] 
+if [ $? -eq 0 ]
 then
 	PROTOCOL='http'
 else
@@ -60,7 +65,7 @@ start() {
         echo "Startup suppressed: ${LOCKFILE} contains running pid, startup script is already running"
         exit 1
     fi
-    
+
     # make sure the lockfile is removed when we exit and then claim it
     trap "rm -f ${LOCKFILE}; exit" INT TERM EXIT
     echo $$ > ${LOCKFILE}
@@ -71,6 +76,7 @@ start() {
   -Xms$JAVAMEM -Xmx$JAVAMEM \
   -Xlog:gc*,gc+ref=debug,gc+heap=debug,gc+age=debug:file=/tmp/gc-%p-%t.log:tags,uptime,time,level:filecount=7,filesize=10m \
   ${REFLECTIVE_ACCESS_ARGS} \
+  ${NASHORN_ARGS} \
   ${JAVAARGS} \
   -jar looker.jar start ${LOOKERARGS}
 


### PR DESCRIPTION
In the JDK 11 Nashorn engine, optimistic types are enabled by default. This causes larger spikes in JVM Metaspace usage under some circumstances.

Switching this back to the same configuration as the default in JDK 8 to increase compatibility with JDK 8 memory requirements.

Optimistic Types Doc: https://openjdk.org/jeps/196

Internal issue Id: b/276950193
Change-Id: I795bb2029c7c261d8964da19adccd1d810ae1eaa